### PR TITLE
[#13] 수정사항 추가

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -99,3 +99,8 @@
 # Please add these rules to your existing keep rules in order to suppress warnings.
 # This is generated automatically by the Android Gradle plugin.
 -dontwarn com.google.protobuf.java_com_google_android_gmscore_sdk_target_granule__proguard_group_gtm_N1281923064GeneratedExtensionRegistryLite$Loader
+
+# Retrofit interface
+-keep interface * {
+    @retrofit2.http.* <methods>;
+}


### PR DESCRIPTION
## issue #13 관련 추가 수정

``` kotlin
// ERROR_LOG:
java.lang.IllegalArgumentException: Unable to create call adapter for interface D3.b
for method d.a
  // at ...
Caused by: java.lang.IllegalArgumentException: Call return type must be parameterized as Call<Foo> or Call<? extends Foo>
  // at ...
```

- 문제: retrofit interface 의 return type 제네릭을 인식하지 못함
- 해결: retrofit interface 난독화 명시적 해제

---

- 기존에는 문제가 없었으나, Android 35 Update 의 부수 작업인 AGP 및 kotlin 업그레이드로 인해 proguard/R8 규칙 적용 방식이 변경되어 문제가 발생한 것으로 추정됨

