### PR TITLE
[#18] 앱 실행시 강제 종료 현상 수정

### DIFF
--- a/app/src/main/java/kr/djspi/pipe01/Intro.kt
+++ b/app/src/main/java/kr/djspi/pipe01/Intro.kt
@@ -43,7 +43,7 @@ class Intro : AppCompatActivity() {
 
         setContentView(R.layout.activity_intro)
 
-        if (BuildConfig.BUILD_TYPE == "release") {
+        if (!BuildConfig.DEBUG) {
             val installer = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 packageManager.getInstallSourceInfo(packageName).installingPackageName
             } else {

--- a/app/src/main/java/kr/djspi/pipe01/Intro.kt
+++ b/app/src/main/java/kr/djspi/pipe01/Intro.kt
@@ -23,14 +23,15 @@ import com.google.android.play.core.install.InstallStateUpdatedListener
 import com.google.android.play.core.install.model.AppUpdateType
 import com.google.android.play.core.install.model.InstallStatus
 import com.google.android.play.core.install.model.UpdateAvailability
+import kr.djspi.pipe01.util.messageDialog
 import kotlin.math.ceil
 import kotlin.math.roundToLong
-import kotlin.system.exitProcess
 
 class Intro : AppCompatActivity() {
 
     private lateinit var appUpdateManager: AppUpdateManager
     private var listener: InstallStateUpdatedListener? = null
+    private var isBlockedByDialog = false
 
     /**
      * (isDelayed) 지정 시간 후 전환되는 스플래시 화면
@@ -49,10 +50,12 @@ class Intro : AppCompatActivity() {
                 packageManager.getInstallerPackageName(packageName)
             }
             Log.d("SPI", "IntroActivity\nPackageName: $installer")
+
             if (installer != "com.android.vending") {
-                finishAffinity()
-                System.runFinalization()
-                exitProcess(0)
+                // Google Play Store 에서 앱 다운로드하도록 유도
+                isBlockedByDialog = true
+                messageDialog(14, getString(R.string.popup_error_unknown_path_installed), false)
+                return
             }
         }
     }
@@ -60,6 +63,12 @@ class Intro : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         Log.d("SPI", "IntroActivity\nonResume()")
+
+        if (isBlockedByDialog) {
+            Log.d("SPI", "IntroActivity\nBlocked by installer check dialog")
+            return
+        }
+
         // ref: 인앱 업데이트 지원 (https://developer.android.com/guide/playcore/in-app-updates/kotlin-java?hl=ko)
         appUpdateManager = AppUpdateManagerFactory.create(this)
         checkUpdate()

--- a/app/src/main/java/kr/djspi/pipe01/LocationUpdate.kt
+++ b/app/src/main/java/kr/djspi/pipe01/LocationUpdate.kt
@@ -8,6 +8,7 @@ import android.location.LocationManager.GPS_PROVIDER
 import android.os.Build
 import android.os.Bundle
 import android.os.Looper
+import android.util.Log
 import com.google.android.gms.location.*
 import com.nabinbhandari.android.permissions.PermissionHandler
 import com.nabinbhandari.android.permissions.Permissions
@@ -93,7 +94,7 @@ abstract class LocationUpdate : BaseActivity() {
         Permissions.check(context, permissions, null, null, object : PermissionHandler() {
                 override fun onGranted() {
                     requestingLocationUpdates = true
-                    println("Granted: ${permissions.toList().joinToString(",")}")
+                    Log.d("SPI", "Granted: ${permissions.toList().joinToString(",")}")
                 }
 
                 override fun onDenied(context: Context, deniedPermissions: ArrayList<String>) {

--- a/app/src/main/java/kr/djspi/pipe01/fragment/MessageDialog.kt
+++ b/app/src/main/java/kr/djspi/pipe01/fragment/MessageDialog.kt
@@ -65,6 +65,7 @@ class MessageDialog : DialogFragment(), OnClickListener {
                 }
                 dismiss()
             }
+
             R.id.button_close -> {
                 returnToMain = false
                 dismiss()
@@ -79,6 +80,7 @@ class MessageDialog : DialogFragment(), OnClickListener {
             0 -> { // 일반 메시지 전달
                 setVisibilityToGone()
             }
+
             1 -> { // (공통) 위치 기능이 꺼져 있음
                 title.text = "주의"
                 contentsSub.text = fromHtml(getString(R.string.popup_location_on_sub))
@@ -89,6 +91,7 @@ class MessageDialog : DialogFragment(), OnClickListener {
                     dismiss()
                 }
             }
+
             2 -> { // (공통) NFC 기능이 꺼져 있음
                 title.text = "주의"
                 contentsSub.text = fromHtml(getString(R.string.popup_nfc_on_sub))
@@ -97,6 +100,7 @@ class MessageDialog : DialogFragment(), OnClickListener {
                     dismiss()
                 }
             }
+
             3 -> { // (MainActivity.kt) 정품 SPI 가 아닌 태그가 태깅되었음
                 setVisibilityToGone()
                 title.text = "주의"
@@ -108,9 +112,11 @@ class MessageDialog : DialogFragment(), OnClickListener {
                     exitProcess(0)
                 }
             }
+
             4 -> { // (MainActivity.kt) 태그 정보 조회 실패
                 setVisibilityToGone()
             }
+
             5 -> { // (SpiPostActivity.kt) 쓰기 작업 이후 수정이 불가함을 안내
                 setVisibilityToGone()
                 title.text = "주의"
@@ -118,38 +124,47 @@ class MessageDialog : DialogFragment(), OnClickListener {
                 buttonDismiss.visibility = View.VISIBLE
                 buttonDismiss.text = "이전"
             }
+
             6 -> { // (SpiPostActivity.kt) 정보가 정상적으로 기록됨
                 setVisibilityToGone()
                 returnToMain = true
             }
+
             7 -> { // (SpiPostActivity.kt) 하나 이상의 관로 정보 등록 과정에서 에러 발생 안내
                 contents.text = getString(R.string.popup_error_set)
                 contentsSub.text = tag
             }
+
             8 -> { // (공통) 서버와의 통신 에러
                 contents.text = getString(R.string.popup_error_comm)
                 setVisibilityToGone()
             }
+
             9 -> { // (MainActivity.kt) 앱 시작 시 절전모드가 실행중인지 확인
                 title.text = "주의"
                 contentsSub.text = getString(R.string.popup_power_save_sub)
             }
+
             10 -> { // (BaseActivity.kt) 위치 정보를 가져오지 못하여 지도보기를 실행하지 못함
                 title.text = "주의"
                 contentsSub.text = getString(R.string.popup_error_location_count_exceed_sub)
             }
+
             11 -> { // (MainActivity.kt) SPI 제품 초기화 개편 (선로종류, 형태, 관리기관 추가) 후 이전 초기화 제품에 대한 안내
                 contents.text = fromHtml(tag!!)
                 setVisibilityToGone()
             }
+
             12 -> { // (SpiPostActivity.kt) 정보를 등록하려는 태그와 실제 태깅된 태그가 다를 때 등록 거부
                 contentsSub.text = getString(R.string.popup_error_serial_mismatch_sub)
             }
+
             13 -> { // (SpiLocationActivity.kt) 관로 이격거리(수직 또는 수평)가 0 이상임에도 사용자가 SPI 설치지점을 관로위치와 동일한 곳으로 입력을 시도
                 setVisibilityToGone()
                 title.text = "주의"
                 contents.text = fromHtml(getString(R.string.nfc_info_read_contents_distance, tag!!))
             }
+
             14 -> { // (Intro.kt) Google Play Store 가 아닌 다른 경로로 설치된 앱 실행 거부
                 setVisibilityToGone()
                 title.text = "오류"
@@ -186,6 +201,7 @@ class MessageDialog : DialogFragment(), OnClickListener {
     }
 
     companion object {
+
         @JvmStatic
         fun getInstance(issue: Int, cancelable: Boolean): MessageDialog {
             return MessageDialog().apply {

--- a/app/src/main/java/kr/djspi/pipe01/fragment/MessageDialog.kt
+++ b/app/src/main/java/kr/djspi/pipe01/fragment/MessageDialog.kt
@@ -150,6 +150,16 @@ class MessageDialog : DialogFragment(), OnClickListener {
                 title.text = "주의"
                 contents.text = fromHtml(getString(R.string.nfc_info_read_contents_distance, tag!!))
             }
+            14 -> { // (Intro.kt) Google Play Store 가 아닌 다른 경로로 설치된 앱 실행 거부
+                setVisibilityToGone()
+                title.text = "오류"
+                buttonOk.text = "앱 종료"
+                buttonOk.setOnClickListener {
+                    dismiss()
+                    activity?.finishAffinity()
+                    exitProcess(0)
+                }
+            }
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,7 @@
     <string name="popup_error_location_count_exceed_sub">와이파이를 재시작하거나 LTE/5G 데이터 통신으로 변경 후 앱을 재실행해 주세요.</string>
     <string name="popup_error_serial_mismatch">SPI 정보 등록에 실패하였습니다.\nSPI를 재확인해 주세요.</string>
     <string name="popup_error_serial_mismatch_sub">기존에 태깅한 SPI와 다른 장치가 감지되었습니다. 올바른 SPI가 태깅되었는지 재확인해 주세요.</string>
+    <string name="popup_error_unknown_path_installed">Google Play Store 에서 정식 버전을 다운로드하세요.</string>
 
     <!--NaverMapActivity-->
     <string name="pipe_name_00">가스관로</string>


### PR DESCRIPTION
## issue #18 관련 수정

- Google Play Store 에서 다운로드한 앱이 아닐 경우, `Intro` 에서 '오류'를 의미하는 다이얼로그 표출
- 다이얼로그로 앱을 제한함을 의미하는 변수를 추가
-> `onCreate()` 에서 다이얼로그가 닫히지 않은 채로 `onResume()`이 진행되지 않도록 함
(추가)
- Build Type 을 판단하는 `BuildConfig` 값을 `BUILD_TYPE (String type)` 에서 `DEBUG (Boolean type)`로 변경
->  `String`의 오타로 인한 오류를 막고, 명확한 구분을 위해
- `release` 모드에서 출력할 필요 없는 `println` 메세지를 `Log` 로 변경하여, `debug` 모드에서만 출력되도록 함
- ......